### PR TITLE
Hide popup when a user taps on the map on Mobile

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -275,16 +275,27 @@ function imageExists(url, callback) {
   }
 
 var dragged = false;
-onmousedown = function() {
+
+onmousedown = onDragReset;
+ontouchstart = onDragReset;
+
+onmousemove = onDragStart;
+ontouchmove = onDragStart;
+
+onmouseup = onDragEnd;
+ontouchend = onDragEnd;
+
+function onDragReset() {
     dragged = false;
 }
-onmousemove = function() {
+
+function onDragStart() {
     dragged = true;
 }
 
-onmouseup = function(e) {
+function onDragEnd(e) {
     // Check that we're not clicking a marker and that there was no dragging
-    if (e.target.tagName != 'AREA'
+    if (e.target.tagName != 'IMG'
         && dragged == false) {
         clearPopups();
     }


### PR DESCRIPTION
Previously tapping on the map on a phone did not hide popups, leaving them on the screen until a button was clicked. On desktop, clicking a blank part of the map hides any visible popup. This PR just replicates that function with touch events.