### PR TITLE
Center SVGs and only count active spreadsheet rows for stats

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -236,7 +236,7 @@ function placeMarkers(institutions) {
         const numStudents = parseInt(institutions[name].students.length);
         
         // Center 2 digit-long student counters
-        let x = numStudents >= 10 ? 2 : 26;
+        let x = numStudents >= 10 ? 2 : 24;
         // Check if the user is on a mobile device, and adjust svgs accoringly
         if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)){
             var mobile = true;

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -236,7 +236,7 @@ function placeMarkers(institutions) {
         const numStudents = parseInt(institutions[name].students.length);
         
         // Center 2 digit-long student counters
-        let x = numStudents >= 10 ? 2 : 24;
+        let svgX = numStudents >= 10 ? 2 : 24;
         // Check if the user is on a mobile device, and adjust svgs accoringly
         if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)){
             var mobile = true;
@@ -255,7 +255,7 @@ function placeMarkers(institutions) {
                     font-weight: ${mobile ? "normal" : "bold"};
                 }
             </style>
-            <text id="${name.replace(/\s/g, '').replace('&', '')}" x="${x}" y="100">${numStudents}</text>
+            <text id="${name.replace(/\s/g, '').replace('&', '')}" x="${svgX}" y="100">${numStudents}</text>
         </svg>`;
         // backgroundColor: color of the marker, glyphColor: color of the number on the marker, x: centering of the number
         const pinSvgElement = parser.parseFromString(pinSvgString, 'image/svg+xml').documentElement;

--- a/js/statistics.js
+++ b/js/statistics.js
@@ -18,7 +18,14 @@ statistics.button.addEventListener('click', function() {
 function loadStatistics(year, stats) {
     statistics.container.classList.remove('no-data');
     statistics.class.textContent = year;
-    statistics.stats.students.textContent = students.get(year).length;
+
+    let numStudents = 0;
+    for (let submission of students.get(year)) {
+        if (submission['Institution name'] != null) {
+            numStudents++;
+        }
+    }
+    statistics.stats.students.textContent = numStudents;
 
     if (!stats.get(parseInt(year))['Number of destinations']) {
         statistics.container.classList.add('no-data');


### PR DESCRIPTION
Before this change, if any student were present in the google spreadsheet, they would be counted towards the "students displayed" statistic. Now, students can be manually removed from being included in this stat by removing the name of the institution from the spreadsheet (if they want to be removed) so as to not mess up the order of the form.

Single-digit SVG numbers were also better centered.  