### PR TITLE
Change default google form to 2023

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         </div>
         <div id="branding">
             <img id="logo" src="img/gm.svg">
-            <p><a id="submit-destination" target="_blank" rel="noopener" href="https://forms.gle/yyyhf76aV2y7jsw36">Submit your <span id="submit-destination-year">2022</span> destination</a></p>
+            <p><a id="submit-destination" target="_blank" rel="noopener" href="https://forms.gle/F5zgUmvpkLRD49my5">Submit your <span id="submit-destination-year">2022</span> destination</a></p>
             <p class="branding-info">Senior project by <a target="_blank" rel="noopener" href="https://erikboesen.com">Erik Boesen</a> '19</p>
             <p class="branding-info">Maintained by MHS <a href="https://apc-mhs.com">A.P.C.</a></p>
         </div>


### PR DESCRIPTION
Makes the default google form link [here](https://forms.gle/F5zgUmvpkLRD49my5) for the class of 2023.

(Makes it load faster and does not have to wait for all the pins to load)